### PR TITLE
Add IDEX controls to the Toolhead panel

### DIFF
--- a/src/components/panels/ToolheadControlPanel.vue
+++ b/src/components/panels/ToolheadControlPanel.vue
@@ -2,19 +2,11 @@
     <panel
         v-if="klipperReadyForGui"
         :icon="mdiGamepad"
-        :title="$t('Panels.ToolheadControlPanel.Headline').toString()"
+        :title="$t(headline)"
         :collapsible="true"
         card-class="toolhead-control-panel">
         <!-- PANEL-HEADER 3-DOT-MENU -->
-        <template
-            v-if="
-                (controlStyle !== 'bars' && (existsZtilt || existsQGL)) ||
-                existsBedScrews ||
-                existsBedTilt ||
-                existsDeltaCalibrate ||
-                existsScrewsTilt
-            "
-            #buttons>
+        <template v-if="showButtons" #buttons>
             <v-menu left offset-y :close-on-content-click="false" class="pa-0">
                 <template #activator="{ on, attrs }">
                     <v-btn icon tile v-bind="attrs" :disabled="['printing'].includes(printer_state)" v-on="on">
@@ -91,22 +83,24 @@
                 </v-list>
             </v-menu>
         </template>
+        <!-- IDEX CONTROL -->
+        <idex-control v-if="isIdex" class="py-0 pt-3" />
         <!-- MOVE TO CONTROL -->
-        <move-to-control class="py-0 pt-3"></move-to-control>
+        <move-to-control class="py-0 pt-3" />
         <!-- AXIS CONTROL -->
         <v-container v-if="axisControlVisible">
-            <component :is="`${controlStyle}-control`"></component>
+            <component :is="`${controlStyle}-control`" />
         </v-container>
         <!-- Z-OFFSET CONTROL -->
-        <v-divider :class="{ 'mt-3': !axisControlVisible }"></v-divider>
+        <v-divider :class="{ 'mt-3': !axisControlVisible }" />
         <v-container>
-            <zoffset-control></zoffset-control>
+            <zoffset-control />
         </v-container>
         <!-- SPEED FACTOR -->
-        <v-divider></v-divider>
+        <v-divider />
         <v-container>
             <tool-slider
-                :label="$t('Panels.ToolheadControlPanel.SpeedFactor').toString()"
+                :label="$t('Panels.ToolheadControlPanel.SpeedFactor')"
                 :icon="mdiSpeedometer"
                 :target="speedFactor"
                 :min="1"
@@ -116,7 +110,7 @@
                 :dynamic-range="true"
                 :has-input-field="true"
                 command="M220"
-                attribute-name="S"></tool-slider>
+                attribute-name="S" />
         </v-container>
     </panel>
 </template>
@@ -129,6 +123,7 @@ import CircleControl from '@/components/panels/ToolheadControls/CircleControl.vu
 import ControlMixin from '@/components/mixins/control'
 import CrossControl from '@/components/panels/ToolheadControls/CrossControl.vue'
 import MoveToControl from '@/components/panels/ToolheadControls/MoveToControl.vue'
+import IdexControl from '@/components/panels/ToolheadControls/IdexControl.vue'
 import Panel from '@/components/ui/Panel.vue'
 import ToolSlider from '@/components/inputs/ToolSlider.vue'
 import ZoffsetControl from '@/components/panels/ToolheadControls/ZoffsetControl.vue'
@@ -140,6 +135,7 @@ import { mdiDotsVertical, mdiEngineOff, mdiGamepad, mdiSpeedometer, mdiMenuDown,
         CircleControl,
         CrossControl,
         MoveToControl,
+        IdexControl,
         Panel,
         ToolSlider,
         ZoffsetControl,
@@ -171,6 +167,20 @@ export default class ToolheadControlPanel extends Mixins(BaseMixin, ControlMixin
 
     get axisControlVisible() {
         return !(this.isPrinting && (this.$store.state.gui.control.hideDuringPrint ?? false))
+    }
+
+    get showButtons() {
+        if (this.controlStyle !== 'bars' && (this.existsZtilt || this.existsQGL)) return true
+
+        return this.existsBedScrews || this.existsBedTilt || this.existsDeltaCalibrate || this.existsScrewsTilt
+    }
+
+    get headline(): string {
+        return this.isIdex ? 'Panels.ToolheadControlPanel.IdexHeadline' : 'Panels.ToolheadControlPanel.Headline'
+    }
+
+    get isIdex(): boolean {
+        return 'dual_carriage' in this.$store.state.printer
     }
 }
 </script>

--- a/src/components/panels/ToolheadControls/IdexControl.vue
+++ b/src/components/panels/ToolheadControls/IdexControl.vue
@@ -1,0 +1,140 @@
+<template>
+    <v-container class="py-0">
+        <v-item-group class="_btn-group py-0">
+            <v-btn
+                class="_btn-qs flex-grow-1 px-1"
+                :disabled="isPrinting || !homedAxes.includes('xyz')"
+                :loading="loadings.includes('idex_single')"
+                :style="{
+                    'background-color': idexMode != 'copy' && idexMode != 'mirror' ? primaryColor : '',
+                    color: idexMode != 'copy' && idexMode != 'mirror' ? primaryTextColor : '',
+                }"
+                dense
+                @click="doSend('IDEX_SINGLE')">
+                {{ $t('Panels.ToolheadControlPanel.SingleMode') }}
+            </v-btn>
+            <v-btn
+                class="_btn-qs flex-grow-1 px-1"
+                :disabled="isPrinting || !homedAxes.includes('xyz')"
+                :loading="loadings.includes('idex_copy')"
+                :style="{
+                    'background-color': idexMode == 'copy' ? primaryColor : '',
+                    color: idexMode == 'copy' ? primaryTextColor : '',
+                }"
+                dense
+                @click="doSend('IDEX_COPY')">
+                {{ $t('Panels.ToolheadControlPanel.CopyMode') }}
+            </v-btn>
+            <v-btn
+                class="_btn-qs flex-grow-1 px-1"
+                :disabled="isPrinting || !homedAxes.includes('xyz')"
+                :loading="loadings.includes('idex_mirror')"
+                :style="{
+                    'background-color': idexMode == 'mirror' ? primaryColor : '',
+                    color: idexMode == 'mirror' ? primaryTextColor : '',
+                }"
+                dense
+                @click="doSend('IDEX_MIRROR')">
+                {{ $t('Panels.ToolheadControlPanel.MirrorMode') }}
+            </v-btn>
+            <v-btn
+                class="_btn-qs flex-grow-1 px-1"
+                :disabled="isPrinting || !homedAxes.includes('xyz') || idexMode == 'copy' || idexMode == 'mirror'"
+                :loading="loadings.includes('idex_park')"
+                dense
+                @click="doSend('IDEX_PARK')">
+                {{ $t('Panels.ToolheadControlPanel.Park') }}
+            </v-btn>
+        </v-item-group>
+    </v-container>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Watch } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import ControlMixin from '@/components/mixins/control'
+
+@Component
+export default class IdexControl extends Mixins(BaseMixin, ControlMixin) {
+    get isPrinting() {
+        return ['printing'].includes(this.printer_state)
+    }
+
+    get homedAxes(): string {
+        return this.$store.state.printer?.toolhead?.homed_axes ?? ''
+    }
+
+    get idexMode(): string {
+        return this.$store.state.printer.dual_carriage?.carriage_1?.toString().toLowerCase()
+    }
+
+    get primaryColor(): string {
+        return this.$store.state.gui.uiSettings.primary
+    }
+
+    get primaryTextColor(): string {
+        let splits = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(this.primaryColor)
+        if (splits) {
+            const r = parseInt(splits[1], 16) * 0.2126
+            const g = parseInt(splits[2], 16) * 0.7152
+            const b = parseInt(splits[3], 16) * 0.0722
+            const perceivedLightness = (r + g + b) / 255
+
+            return perceivedLightness > 0.7 ? '#222' : '#fff'
+        }
+
+        return '#ffffff'
+    }
+
+    doSend(gcode: string): void {
+        this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
+        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: gcode.toLowerCase() })
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.v-btn-toggle {
+    width: 100%;
+}
+
+._btn-group {
+    border-radius: 4px;
+    display: inline-flex;
+    flex-wrap: nowrap;
+    max-width: 100%;
+    min-width: 100%;
+    width: 100%;
+
+    .v-btn {
+        border-radius: 0;
+        border-color: rgba(255, 255, 255, 0.12);
+        border-style: solid;
+        border-width: thin;
+        box-shadow: none;
+        height: 28px;
+        opacity: 0.8;
+        min-width: auto !important;
+    }
+
+    .v-btn:first-child {
+        border-top-left-radius: inherit;
+        border-bottom-left-radius: inherit;
+    }
+
+    .v-btn:last-child {
+        border-top-right-radius: inherit;
+        border-bottom-right-radius: inherit;
+    }
+
+    .v-btn:not(:first-child) {
+        border-left-width: 0;
+    }
+}
+
+._btn-qs {
+    font-size: 0.8rem !important;
+    font-weight: 400;
+    max-height: 28px;
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -706,7 +706,12 @@
             "Relative": "relative",
             "SettingsInterfaceControl": "Settings > Interface > Control",
             "SpeedFactor": "Speed factor",
-            "ZTilt": "Z-Tilt"
+            "ZTilt": "Z-Tilt",
+            "IdexHeadline": "Idex Toolhead",
+            "SingleMode": "SINGLE MODE",
+            "CopyMode": "COPY MODE",
+            "MirrorMode": "MIRROR MODE",
+            "Park": "PARK"
         },
         "WebcamPanel": {
             "All": "All",


### PR DESCRIPTION
## Description

this pr adds 4 additional buttons to the toolhead panel. they show the current idex mode state and lets you switch them as well.

- state is coming from klipper
- buttons do call the macros `IDEX_SINGLE`, `IDEX_COPY`, `IDEX_MIRROR` and `IDEX_PARK`

## Related Tickets & Documents

https://www.youtube.com/watch?v=ShGbLKXQLQk

## Mobile & Desktop Screenshots/Recordings

## [optional] Are there any post-deployment tasks we need to perform?

Signed-off-by: Helge Keck <helgekeck@hotmail.com>